### PR TITLE
Edits to improve site accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ A copy of this repository will be made in your own github account.
 
 In "myname/dreuprojecttemplate", click on "Settings" near the top right hand of the window. Change the repository name from "dreuprojecttemplate" to to "myname.github.io". ("myname" must match your GitHub user name exactly.)
 
-Scroll down til you see "GitHub pages" and choose "Master" instead of "None".
+Scroll down until you see "GitHub pages" and choose "master" instead of "None".
 
-If you already have a GitHub site, then you can make this a project site rather than your personal site.
+If you already have a GitHub site, then you can make this a project site rather than your personal site. If you do, you may need to rename "master" to "gh-pages" to trigger deployment.
 
 ### Step 4) Customize and view your site
 

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ description: Summer 2020 DREU Project
 
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
 avatar: https://raw.githubusercontent.com/barryclark/jekyll-now/master/images/jekyll-logo.png
+avatar_alt_text: describe_your_avatar_here
 
 #
 # Flags below are optional
@@ -18,7 +19,7 @@ avatar: https://raw.githubusercontent.com/barryclark/jekyll-now/master/images/je
 # Includes an icon in the footer for each username you enter
 footer-links:
   dribbble:
-  email: yourmail@mail.com
+  email: your.mail@mail.com
   facebook:
   flickr:
   rss: # just type anything here for a working RSS icon

--- a/_config.yml
+++ b/_config.yml
@@ -6,11 +6,11 @@
 name: Your Name
 
 # Short bio or description (displayed in the header)
-description: Summer 2020 DREU Project
+description: Summer 2023 DREU Project
 
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
 avatar: https://raw.githubusercontent.com/barryclark/jekyll-now/master/images/jekyll-logo.png
-avatar_alt_text: describe_your_avatar_here
+avatar_alt_text: describe_your_avatar_here # don't redundantly say it's an image. See more tips here: https://www.a11yproject.com/posts/alt-text/ 
 
 #
 # Flags below are optional

--- a/_includes/svg-icons.html
+++ b/_includes/svg-icons.html
@@ -1,13 +1,13 @@
-{% if site.footer-links.dribbble %}<a href="https://dribbble.com/{{ site.footer-links.dribbble }}"><i class="svg-icon dribbble"></i></a>{% endif %}
-{% if site.footer-links.email %}<a href="mailto:{{ site.footer-links.email }}"><i class="svg-icon email"></i></a>{% endif %}
-{% if site.footer-links.facebook %}<a href="https://www.facebook.com/{{ site.footer-links.facebook }}"><i class="svg-icon facebook"></i></a>{% endif %}
-{% if site.footer-links.flickr %}<a href="https://www.flickr.com/{{ site.footer-links.flickr }}"><i class="svg-icon flickr"></i></a>{% endif %}
-{% if site.footer-links.github %}<a href="https://github.com/{{ site.footer-links.github }}"><i class="svg-icon github"></i></a>{% endif %}
-{% if site.footer-links.instagram %}<a href="https://instagram.com/{{ site.footer-links.instagram }}"><i class="svg-icon instagram"></i></a>{% endif %}
-{% if site.footer-links.linkedin %}<a href="https://www.linkedin.com/in/{{ site.footer-links.linkedin }}"><i class="svg-icon linkedin"></i></a>{% endif %}
-{% if site.footer-links.pinterest %}<a href="https://www.pinterest.com/{{ site.footer-links.pinterest }}"><i class="svg-icon pinterest"></i></a>{% endif %}
-{% if site.footer-links.rss %}<a href="{{ site.baseurl }}/feed.xml"><i class="svg-icon rss"></i></a>{% endif %}
-{% if site.footer-links.twitter %}<a href="https://www.twitter.com/{{ site.footer-links.twitter }}"><i class="svg-icon twitter"></i></a>{% endif %}
-{% if site.footer-links.stackoverflow %}<a href="http://stackoverflow.com/{{ site.footer-links.stackoverflow }}"><i class="svg-icon stackoverflow"></i></a>{% endif %}
-{% if site.footer-links.youtube %}<a href="https://youtube.com/{{ site.footer-links.youtube }}"><i class="svg-icon youtube"></i></a>{% endif %}
-{% if site.footer-links.googleplus %}<a href="https://plus.google.com/{{ site.footer-links.googleplus }}"><i class="svg-icon googleplus"></i></a>{% endif %}
+{% if site.footer-links.dribbble %}<a href="https://dribbble.com/{{ site.footer-links.dribbble }}" title="Dribbble"><i class="svg-icon dribbble"></i></a>{% endif %}
+{% if site.footer-links.email %}<a href="mailto:{{ site.footer-links.email }}" title="Email"><i class="svg-icon email"></i></a>{% endif %}
+{% if site.footer-links.facebook %}<a href="https://www.facebook.com/{{ site.footer-links.facebook }}" title="Facebook"><i class="svg-icon facebook"></i></a>{% endif %}
+{% if site.footer-links.flickr %}<a href="https://www.flickr.com/{{ site.footer-links.flickr }}" title="Flickr"><i class="svg-icon flickr"></i></a>{% endif %}
+{% if site.footer-links.github %}<a href="https://github.com/{{ site.footer-links.github }}" title="GitHub"><i class="svg-icon github"></i></a>{% endif %}
+{% if site.footer-links.instagram %}<a href="https://instagram.com/{{ site.footer-links.instagram }}" title="Instagram"><i class="svg-icon instagram"></i></a>{% endif %}
+{% if site.footer-links.linkedin %}<a href="https://www.linkedin.com/in/{{ site.footer-links.linkedin }}" title="LinkedIn"><i class="svg-icon linkedin"></i></a>{% endif %}
+{% if site.footer-links.pinterest %}<a href="https://www.pinterest.com/{{ site.footer-links.pinterest }}" title="Pinterest"><i class="svg-icon pinterest"></i></a>{% endif %}
+{% if site.footer-links.rss %}<a href="{{ site.baseurl }}/feed.xml" title="RSS"><i class="svg-icon rss"></i></a>{% endif %}
+{% if site.footer-links.twitter %}<a href="https://www.twitter.com/{{ site.footer-links.twitter }}" title="Twitter"><i class="svg-icon twitter"></i></a>{% endif %}
+{% if site.footer-links.stackoverflow %}<a href="http://stackoverflow.com/{{ site.footer-links.stackoverflow }}" title="StackOverflow"><i class="svg-icon stackoverflow"></i></a>{% endif %}
+{% if site.footer-links.youtube %}<a href="https://youtube.com/{{ site.footer-links.youtube }}" title="YouTube"><i class="svg-icon youtube"></i></a>{% endif %}
+{% if site.footer-links.googleplus %}<a href="https://plus.google.com/{{ site.footer-links.googleplus }}" title="Google Plus"><i class="svg-icon googleplus"></i></a>{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,6 +38,10 @@
             <p class="site-description">{{ site.description }}</p>
           </div>
 
+          <nav>
+            <a href="{{ site.baseurl }}/">Home</a>
+            <a href="{{ site.baseurl }}/blog/">Blog</a>
+          </nav>
         </header>
       </div>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,8 @@
   </head>
 
   <body>
+    <a href="#main" class="skip-to-main-content-link">Skip to main content</a>
+    
     <div class="wrapper-masthead">
       <div class="container">
         <header class="masthead clearfix">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,11 +13,21 @@
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
     <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->
+
+     <!-- jQuery for skipping to main content -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script>
+        $(document).ready(function () {
+            $("#skipper").click(function () {
+                $('#mainContent').attr('tabIndex', -1).focus();
+            });
+        });
+    </script>
   </head>
 
   <body>
-    <a href="#main" class="skip-to-main-content-link">Skip to main content</a>
-    
+    <a href="#main" id="skipper" class="skip-to-main-content-link">Skip to main content</a>
+
     <div class="wrapper-masthead">
       <div class="container">
         <header class="masthead clearfix">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
     <div class="wrapper-masthead">
       <div class="container">
         <header class="masthead clearfix">
-          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" /></a>
+          <img src="{{ site.avatar }}" class="site-avatar" alt="{{ site.avatar_alt_text }}"/>
 
           <div class="site-info">
             <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,6 @@ layout: default
     Written on {{ page.date | date: "%B %e, %Y" }}
   </div>
 
-  <a href="/blog">Return to blog</a>
+  <a href="{{ site.baseurl }}/blog">Return to blog</a>
 
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,4 +13,6 @@ layout: default
     Written on {{ page.date | date: "%B %e, %Y" }}
   </div>
 
+  <a href="/blog">Return to blog</a>
+
 </article>

--- a/_posts/2023-06-01-week1.md
+++ b/_posts/2023-06-01-week1.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Week 1
+date: 2023-06-01T10:20:00Z
 ---
 
 Text here!

--- a/_posts/2023-06-01-week1.md
+++ b/_posts/2023-06-01-week1.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Week 1
+description: Description here!
 date: 2023-06-01T10:20:00Z
 ---
 

--- a/blog.html
+++ b/blog.html
@@ -4,16 +4,17 @@ layout: default
 
 <div class="posts">
   {% for post in site.posts %}
-    <article class="post">
-
-      <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+    <article class="post-entry">
+      <header class="entry-header">
+        <h1>{{ post.title }}</h1>
+      </header>
 
       <div class="entry">
         {{ post.description }}
         <!-- {{ post.excerpt }} -->
       </div>
 
-      <!-- <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a> -->
+      <a class="entry-link" aria-label="{{ post.title }}" href="{{ site.baseurl }}{{ post.url }}"></a>
     </article>
   {% endfor %}
 </div>

--- a/blog.html
+++ b/blog.html
@@ -10,7 +10,7 @@ layout: default
         <h1>{{ post.title }}</h1>
       </header>
 
-      <div class="entry">
+      <div class="entry-description">
         {{ post.description }}
         <!-- {{ post.excerpt }} -->
       </div>

--- a/blog.html
+++ b/blog.html
@@ -4,6 +4,7 @@ layout: default
 
 <div class="posts">
   {% for post in site.posts %}
+  <a href="{{ site.baseurl }}{{ post.url }}">
     <article class="post-entry">
       <header class="entry-header">
         <h1>{{ post.title }}</h1>
@@ -13,8 +14,7 @@ layout: default
         {{ post.description }}
         <!-- {{ post.excerpt }} -->
       </div>
-
-      <a class="entry-link" aria-label="{{ post.title }}" href="{{ site.baseurl }}{{ post.url }}"></a>
     </article>
+  </a>
   {% endfor %}
 </div>

--- a/blog.html
+++ b/blog.html
@@ -9,10 +9,10 @@ layout: default
       <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
 
       <div class="entry">
-        {{ post.excerpt }}
+        {{ post.excerpt }}...
       </div>
 
-      <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
+      <!-- <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a> -->
     </article>
   {% endfor %}
 </div>

--- a/blog.html
+++ b/blog.html
@@ -9,7 +9,8 @@ layout: default
       <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
 
       <div class="entry">
-        {{ post.excerpt }}...
+        {{ post.description }}
+        <!-- {{ post.excerpt }} -->
       </div>
 
       <!-- <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a> -->

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Summer 2020 DREU Project Site
+title: Summer 2023 DREU Project Site
 ---
 
 * TOC
@@ -19,7 +19,3 @@ Mentor info goes here.
 Project description goes here.
 
 [My Final Report](files/finalreport.pdf)
-
-## My Blog
-
-[My Blog](blog.html)

--- a/style.scss
+++ b/style.scss
@@ -296,6 +296,14 @@ nav {
 }
 
 // post-entry and associated variables, html from the PaperMod Jekyll Theme
+.entry-link { // fill the tile
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0
+}
+
 .post-entry:hover .entry-header h1 {
   color: $blue;
 }

--- a/style.scss
+++ b/style.scss
@@ -142,6 +142,14 @@ img {
     clear: both;
 }
 
+/* Variables (used for post-entry) */
+:root {
+  --gap: 24px;
+  --radius: 8px;
+  --entry: rgb(255, 255, 255);
+  --border: rgb(238, 238, 238);
+}
+
 /*********************/
 /* LAYOUT / SECTIONS */
 /*********************/
@@ -286,6 +294,33 @@ nav {
     font-size: 15px;
   }
 }
+
+// post-entry and associated variables, html from the PaperMod Jekyll Theme
+.post-entry:hover .entry-header h1 {
+  color: $blue;
+}
+
+.post-entry:hover header.entry-header {
+  color: $blue;
+}
+
+.post-entry:active {
+  transform: scale(.96)
+}
+
+.post-entry {
+  position: relative;
+  margin-bottom: var(--gap);
+  padding: var(--gap);
+  background: var(--entry);
+  border-radius: var(--radius);
+  transition: transform .1s;
+  border: 1px solid var(--border);
+
+  a.entry-link:hover {
+    color: $blue;
+  }
+} 
 
 .wrapper-footer {
   margin-top: 50px;

--- a/style.scss
+++ b/style.scss
@@ -210,6 +210,22 @@ img {
   }
 }
 
+.skip-to-main-content-link {
+  position: absolute;
+  left: -9999px;
+  z-index: 999;
+  padding: 1em;
+  background-color: black;
+  color: white;
+  opacity: 0;
+}
+
+.skip-to-main-content-link:focus {
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 1;
+}
+
 nav {
   float: right;
   margin-top: 23px; // @TODO: Vertically middle align

--- a/style.scss
+++ b/style.scss
@@ -249,10 +249,11 @@ nav {
 
   a {
     margin-left: 20px;
-    color: $darkGray;
+    color: $blue;
     text-align: right;
     font-weight: 300;
     letter-spacing: 1px;
+    padding: 1em;
 
     @include mobile {
       margin: 0 10px;

--- a/style.scss
+++ b/style.scss
@@ -147,7 +147,7 @@ img {
   --gap: 24px;
   --radius: 8px;
   --entry: rgb(255, 255, 255);
-  --border: rgb(238, 238, 238);
+  --border: rgb(170, 170, 170);
 }
 
 /*********************/
@@ -164,7 +164,7 @@ img {
 
 .masthead {
   padding: 20px 0;
-  border-bottom: 1px solid $lightGray;
+  border-bottom: 1px solid var(--border);
 
   @include mobile {
     text-align: center;
@@ -297,13 +297,6 @@ nav {
 }
 
 // post-entry and associated variables, html from the PaperMod Jekyll Theme
-.entry-link { // fill the tile
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0
-}
 
 .post-entry:hover .entry-header h1 {
   color: $blue;
@@ -325,11 +318,15 @@ nav {
   border-radius: var(--radius);
   transition: transform .1s;
   border: 1px solid var(--border);
+}
 
-  a.entry-link:hover {
+.entry-header h1 {
     color: $blue;
-  }
-} 
+}
+
+.entry-description {
+    color: black;
+}
 
 .wrapper-footer {
   margin-top: 50px;


### PR DESCRIPTION
Hi!

To improve site accessibility and flow, especially for sighted keyboard users and non-sighted users, I have introduced the following key changes (details specified in commit messages): 

- Remove the site avatar from the home link, so as to allow for alt text describing a student's features. Adding a space for a student to specify alt text and linking alt text recommendations in the comments. b5c160d38b6e199e8c38135f10920da35e77a7ac
- Add alt text to the icons in the footer, which currently simply are all read as 'link'. 68181c213d40baa304873e9f8bf3f38ff2579494
- Add a more intuitive navbar and (in accordance with w3 recommendations) a skip to main content link. 218ecfaca6dbe1d7045dcee0382262dcdcacd4cd, a7e33a4d99319b501b68ba075380ff0470d90fc5 **NOTE:** With VoiceOver on Mac, it is known that the [page may continue reading without skipping to content](https://www.sitepoint.com/community/t/skip-links-etc-and-screen-readers/83936). But tabbing forward should work as expected, via a jQuery workaround. 89d7c82777aa8e67199a4825e819b46d91330db8
- Add a return to blog link at the bottom of each post (a previous/next post link would be more ideal, but is harder to implement automatically), to aid in keyboard navigation. 1e296b0805d766e279168055c7c28d4cd453be39
- Make posts on the block page clickable tiles, with post title and description (not excerpt, but code can be modified to read an excerpt if still desired). This greatly reduces the amount of traversing through the DOM a non-sighted user may have to undergo, especially on the Mac (as opposed to JAWS). Having a description instead of an excerpt and "Read More" link also cuts the number of links in half for all keyboard users, since the title accomplishes the same purpose. 2483aac6a9926089401fdd699028646851550dfa, 8f8c800cb2723786d251b3a6352d8ab5f8d05fb7
- Enhance color contrast of borders. 174b40e040cac0455de527ad9fdc99d68c8ea75f

I have also made the following changes for instructional purposes:
- Advance the year from 2020 to 2023, and edit the example post to include an example date. e73008e86c263e8b7a694ff619129e740733429f
- Add a note for those deploying on a sub-page of their GitHub Pages website about the potential need to rename the master branch to gh-pages. f9b7388b6714d8bac4dbd7286ebc6349c0c314e6

An example raw repository generated from this template may be found [here](https://christineiym.github.io/dreu-site/).

Testing was done on a MacBook Pro (Big Sur) with Chrome and VoiceOver, exploring all pages and experimenting with multiple posts. 
Limited testing was also conducted with a OnePlus 6T, Android 11, using TalkBalk.

Please feel free to reach me here or via [email](christine.mendoza@unc.edu)!

Thanks!